### PR TITLE
Add script for PGO and add option for using perf for recording methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ nb-configuration.xml
 
 # Plugin directory
 /.quarkus/cli/plugins/
+
+# Profiling
+*.iprof
+*.perf
+*.data

--- a/collect-pgo-and-build-image.sh
+++ b/collect-pgo-and-build-image.sh
@@ -1,0 +1,5 @@
+./mvnw package -Pnative -Dquarkus.native.additional-build-args="--pgo-instrument,--gc=G1"
+cd scripts
+./benchmark.sh -n
+cd ..
+./mvnw package -Pnative -Dquarkus.native.additional-build-args="--pgo=../../scripts/default.iprof,--gc=G1,-g,-H:-DeleteLocalSymbols,-H:+PreserveFramePointer"


### PR DESCRIPTION
This PR adds a new script that creates an instrumented GraalVM native image, then runs the benchmarks with that image to create a default.iprof file, and then uses this file to create an optimized GraalVM native image including debug information.

Also, it adds a new "-r" flag for the benchmarking script that enables the recording of method samples using perf. It later converts those samples into a file that can be opened at https://profiler.firefox.com/.